### PR TITLE
read the vcap_services and make it available for nginx to consume

### DIFF
--- a/bin/boot.sh
+++ b/bin/boot.sh
@@ -15,6 +15,8 @@
 export APP_ROOT=$HOME
 export LD_LIBRARY_PATH=$APP_ROOT/openresty/lib:$LD_LIBRARY_PATH
 
+$(ruby get_env)
+
 conf_file=$APP_ROOT/openresty/nginx/conf/nginx.conf
 
 erb $conf_file > $APP_ROOT/openresty/nginx/conf/nginx-final.conf

--- a/bin/compile
+++ b/bin/compile
@@ -70,3 +70,4 @@ if [[ "$(grep directory: Staticfile)X" != "X" ]]; then
 fi
 
 cp $compile_buildpack_bin/boot.sh .
+cp $compile_buildpack_bin/get_env .

--- a/bin/get_env
+++ b/bin/get_env
@@ -1,0 +1,12 @@
+require 'rubygems'
+require 'json'
+parsed=JSON.parse(ENV['VCAP_SERVICES'])
+parsed.each do |key, array|
+	array.each do |serviceMap|
+		serviceMap["credentials"].each do |index,value|
+			if !(value.class.method_defined? :flatten)
+				print "export vcap_service_"+serviceMap["name"].gsub(/[^0-9a-z ]/i, '')+"_"+index+"="+value.to_s+"\n"
+			end
+		end
+	end
+end


### PR DESCRIPTION
Now the users can do

<%= ENV["vcap_service_name_uri"] %> in the nginx.conf

this in conjunction with the content_by_lua can be a relief to the developers to get access to the VCAP_SERVICES variable from CF.

Sample

```
{
            default_type 'application/json';
            content_by_lua '
                ngx.say(\'{"uri": "<%= ENV["vcap_service_name_uri"] %>"}\');
            ';
        }
```

Please note that any  non-alphanumeric character in the name would be removed (Since unix does not like it in the env)

@muymoo , @billnreed : FYI..
